### PR TITLE
Fix Mortis' second SP name

### DIFF
--- a/brawlcord/data/brawlers.json
+++ b/brawlcord/data/brawlers.json
@@ -620,7 +620,7 @@
             "desc": "Mortis reaps the life essence of Brawler he defeats, restoring **1800** of his health."
         },
         "sp2": {
-            "name": "Snappy Sniping",
+            "name": "Coiled Snake",
             "desc": "Mortis gains a Dash Bar! His dash range is increased by **75%** when the bar is fully charged. It takes **3.5** seconds for the bar to charge when Mortis has all three dashes ready."
         },
         "skins": {


### PR DESCRIPTION
Changed Mortis' second SP name from "Snappy Sniping" to "Coiled Snake"