### PR TITLE
Leaderboard command fixes and improvements

### DIFF
--- a/brawlcord/brawlcord.py
+++ b/brawlcord/brawlcord.py
@@ -1476,10 +1476,7 @@ class Brawlcord(commands.Cog):
         total_guilds = len(self.bot.guilds)
         total_users = len(await self.config.all_users())
 
-        await ctx.send(f"{total_guilds}, {total_users}")
-
-        # for user in self.config.all_users():
-        #     print(user)
+        await ctx.send(f"Total Guilds: {total_guilds}\nTotal Users: {total_users}")
 
     @commands.command(name="upgrades")
     @maintenance()


### PR DESCRIPTION
Leaderboard command now displays user's rank correctly (if not in top 10). It is now also possible to invoke the `leaderboard brawler` command by directly passing name of brawler after `leaderboard`. For example, `leaderboard brawler Shelly` and `leaderboard Shelly` work in the same manner now.