### PR TITLE
Fix empty lists with skins and double odds of brawl box in shop

### DIFF
--- a/brawlcord/brawlcord.py
+++ b/brawlcord/brawlcord.py
@@ -34,7 +34,7 @@ from .utils import Box, default_stats, maintenance
 
 log = logging.getLogger("red.brawlcord")
 
-__version__ = "2.1.1"
+__version__ = "2.1.2"
 __author__ = "Snowsee"
 
 default = {
@@ -2651,6 +2651,29 @@ class Brawlcord(commands.Cog):
             duration = maint["duration"]
 
         await ctx.send(f"**Setting:** {setting}\n**Duration:** {duration}")
+
+    @commands.command()
+    @checks.is_owner()
+    async def fixskins(self, ctx: Context):
+        """Removes empty lists from the skins list."""
+
+        data = await self.config.all_users()
+
+        await ctx.trigger_typing()
+        for user in data:
+            for brawler in data[user]["brawlers"]:
+                skins = data[user]["brawlers"][brawler]["skins"]
+
+                skins = [skin for skin in skins if skin]
+                user_obj = discord.Object(user)
+                try:
+                    await self.config.user(user_obj).set_raw(
+                        "brawlers", brawler, "skins", value=skins
+                    )
+                except Exception:
+                    log.error(f"Error fixing skins for user with ID: {user}")
+
+        await ctx.send("Done! Please check logs for errors.")
 
     async def cog_command_error(self, ctx: Context, error: Exception):
         if not isinstance(

--- a/brawlcord/brawlers.py
+++ b/brawlcord/brawlers.py
@@ -1,18 +1,11 @@
-"""
-This module contains all the Brawler data. Each Brawler has a
-separate class, which extends from the base (Brawler). Perhaps
-subclassing them as `Shotgunners`, `Spawners`, etc would be better.
-"""
-
-
 import random
 
 import discord
 
-from .emojis import emojis, sp_icons, brawler_emojis, rank_emojis
+from .emojis import brawler_emojis, emojis, rank_emojis, sp_icons
 
 
-# credits to Star List, developed by Henry
+# Credits to Star List, developed by Henry.
 brawler_url = "https://www.starlist.pro/brawlers/detail/{}"
 brawler_thumb = "https://www.starlist.pro/assets/brawler/{}.png"
 
@@ -28,7 +21,7 @@ rarity_colors = {
 
 
 class Brawler:
-    """Class to represent a Brawler."""
+    """Base class to represent a Brawler."""
 
     def __init__(self, raw_data: dict, brawler: str):
 
@@ -45,8 +38,19 @@ class Brawler:
         self.sp1 = data["sp1"]
         self.sp2 = data["sp2"]
 
+        self.init()
+
+    def init(self):
+        # These are the stats that are "buffed", unless overridden in specific classes.
+        self.stats = {
+            "health": self.health,
+            "att_damage": self.attack["damage"],
+            "ult_damage": self.ult["damage"]
+        }
+
     def get_stat(self, stat, substat: str = None):
         """Get specific Brawler stat."""
+
         if substat:
             return getattr(self, stat)[substat]
         else:
@@ -54,6 +58,7 @@ class Brawler:
 
     def get_all_stats(self):
         """Get all Brawler stats."""
+
         stats = {
             "health": self.health,
             "attack": self.attack,
@@ -68,42 +73,77 @@ class Brawler:
         return stats
 
     def _health(self, level) -> int:
-        """Function to get health of Brawler of specified power level."""
-        stats = self.buff_stats(level)
+        """Get the health of the Brawler at specified power level."""
 
-        return stats['health']
+        return self.buff_stat(self.health, level)
 
     def _attack(self, level):
-        """Represent the attack ability of the Brawler. """
-        pass
+        """Represents the attack ability of the Brawler."""
+
+        # getting all values
+        # att_range = self.attack["range"]
+        # att_reload = self.attack["reload"]
+        projectiles = self.attack["projectiles"]
+
+        stats = self.buff_stats(level)
+
+        damage = stats['att_damage']
+
+        raw = damage * projectiles * 0.8
+
+        return self.chance_calculation(raw)
 
     def _ult(self, level):
-        """Represent the Super ability of the Brawler."""
-        pass
+        """Represents the Super ability of the Brawler."""
+
+        # getting all values
+        # # ult_range = self.ult["range"]
+        projectiles = self.ult["projectiles"]
+
+        stats = self.buff_stats(level)
+
+        damage = stats['ult_damage']
+
+        raw = damage * projectiles * 0.8
+
+        return self.chance_calculation(raw), None  # None is the spawn health
 
     def _sp1(self):
-        """Function to represent the first SP of the Brawler."""
+        """Represents the first SP of the Brawler."""
         pass
 
     def _sp2(self):
-        """Function to represent the second SP of the Brawler."""
+        """Represents the second SP of the Brawler."""
         pass
 
     def _spawn(self, level):
-        """Represent the spawned character of the Brawler."""
-        return None
+        """Represents the move of the spawned character of the Brawler."""
 
-    def buff_stats(self, stats: dict, level: int):
-        """Get Brawler stats by specified level."""
+    def buff_stats(self, level: int):
+        """Get all Brawler stats buffed by specified level."""
 
         if level == 10:
             level = 9
 
-        for stat in stats:
-            upgrader = stats[stat]/20
-            stats[stat] += int(upgrader * (level - 1))
+        stats = {}
+
+        for stat in self.stats:
+            val = self.stats[stat]
+            if not val:
+                continue
+            stats[stat] = val + int(val/20 * (level - 1))
 
         return stats
+
+    def buff_stat(self, stat: int, level: int):
+        """Get a single Brawler stat buffed by specified level."""
+
+        if level == 10:
+            level = 9
+
+        stat += int(stat/20 * (level - 1))
+
+        return stat
 
     def brawler_info(
         self,
@@ -133,6 +173,7 @@ class Brawler:
             description=self.desc, url=url
         )
         embed.set_thumbnail(url=brawler_thumb.format(brawler_name_url.title()))
+
         if level:
             embed.add_field(name="POWER", value=f"{emojis['xp']} {level}")
             embed.add_field(
@@ -153,116 +194,19 @@ class Brawler:
                 )
         else:
             embed.add_field(name="POWER", value=f"{emojis['xp']} 1")
-        return embed
-
-
-class Shelly(Brawler):
-    """A class to represent Shelly."""
-
-    def _attack(self, level):
-        """Represent the attack ability of Shelly."""
-
-        # getting all values
-        # att_range = self.attack["range"]
-        # att_reload = self.attack["reload"]
-        projectiles = self.attack["projectiles"]
-
-        stats = self.buff_stats(level)
-
-        damage = stats['att_damage']
-
-        raw = damage * projectiles * 0.8
-
-        chance = random.randint(0, 10)
-
-        if chance >= 9:
-            return raw
-        elif chance >= 6:
-            return raw * 0.7
-        elif chance >= 4:
-            return raw * 0.5
-        elif chance >= 2:
-            return raw * 0.3
-        else:
-            return 0
-
-    def _ult(self, level):
-        """Represent the Super ability of Shelly."""
-
-        # getting all values
-        # # ult_range = self.ult["range"]
-        projectiles = self.ult["projectiles"]
-
-        stats = self.buff_stats(level)
-
-        damage = stats['ult_damage']
-
-        raw = damage * projectiles * 0.8
-
-        chance = random.randint(0, 10)
-
-        if chance >= 9:
-            return raw, None
-        elif chance >= 6:
-            return raw * 0.7, None
-        elif chance >= 4:
-            return raw * 0.5, None
-        elif chance >= 2:
-            return raw * 0.3, None
-        else:
-            return 0, None
-
-    def buff_stats(self, level: int):
-        stats = {
-            "health": self.health,
-            "att_damage": self.attack["damage"],
-            "ult_damage": self.ult["damage"]
-        }
-
-        return super().buff_stats(stats, level)
-
-    def brawler_info(
-        self,
-        brawler_name: str,
-        trophies: int = None,
-        pb: int = None,
-        rank: int = None,
-        level: int = None,
-        pp: int = None,
-        next_level_pp: int = None,
-        sp1=False,
-        sp2=False
-    ):
-        """Return embed with Brawler info."""
-
-        embed = super().brawler_info(
-            brawler_name=brawler_name, trophies=trophies, pb=pb, rank=rank,
-            level=level, pp=pp, next_level_pp=next_level_pp, sp1=sp1, sp2=sp2
-        )
 
         if not level:
             level = 1
 
         stats = self.buff_stats(level)
 
-        embed.add_field(
-            name="HEALTH",
-            value=f"{emojis['health']} {stats['health']}"
-        )
+        embed.add_field(name="HEALTH", value=f"{emojis['health']} {stats['health']}")
         embed.add_field(name="SPEED", value=f"{emojis['speed']} {self.speed}")
 
-        attack_desc = f"```{self.attack['desc']}```"
-        attack_str = (
-            attack_desc
-            + f"\n{emojis['damage']} Damage per shell: {stats['att_damage']}"
-        )
+        attack_str = self.attack_info(stats)
         embed.add_field(name="ATTACK", value=attack_str, inline=False)
 
-        super_desc = f"```{self.ult['desc']}```"
-        super_str = (
-            super_desc
-            + f"\n{emojis['super']} Damage per shell: {stats['ult_damage']}"
-        )
+        super_str = self.super_info(stats)
         embed.add_field(name="SUPER", value=super_str, inline=False)
 
         u1 = u2 = ""
@@ -282,86 +226,29 @@ class Shelly(Brawler):
 
         return embed
 
+    def attack_info(self, stats: dict):
+        try:
+            attack_str = self.attack['extra']
+        except KeyError:
+            attack_str = "Damage"
 
-class Nita(Brawler):
-    """A class to represent Nita."""
+        attack_desc = f"```{self.attack['desc']}```"
+        info = f"{attack_desc}\n{emojis['damage']} {attack_str}: {stats['att_damage']}"
 
-    def _attack(self, level):
-        """Represent the attack ability of Nita. """
+        return info
 
-        # getting all values
-        # att_range = self.attack["range"]
-        # att_reload = self.attack["reload"]
-        projectiles = self.attack["projectiles"]
+    def super_info(self, stats: dict):
+        try:
+            super_str = self.ult['extra']
+        except KeyError:
+            super_str = "Damage"
 
-        stats = self.buff_stats(level)
+        super_desc = f"```{self.ult['desc']}```"
+        info = f"{super_desc}\n{emojis['super']} {super_str}: {stats['ult_damage']}"
 
-        damage = stats['att_damage']
+        return info
 
-        raw = damage * projectiles * 0.8
-
-        chance = random.randint(0, 10)
-
-        if chance >= 9:
-            return raw
-        elif chance >= 6:
-            return raw * 0.7
-        elif chance >= 4:
-            return raw * 0.5
-        elif chance >= 2:
-            return raw * 0.3
-        else:
-            return 0
-
-    def _ult(self, level):
-        """Represent the Super ability of Nita."""
-
-        # getting all values
-        # bear = self.ult["bear"]
-        # br_range = bear["range"]
-        # speed = bear["speed"]
-
-        stats = self.buff_stats(level)
-
-        damage = stats["bear_damage"]
-        health = stats["bear_health"]
-
-        raw = damage * 0.8
-
-        chance = random.randint(0, 10)
-
-        if chance >= 9:
-            raw *= 1
-        elif chance >= 6:
-            raw *= 0.7
-        elif chance >= 4:
-            raw *= 0.5
-        elif chance >= 2:
-            raw *= 0.3
-        else:
-            raw = 0
-
-        return raw, health
-
-    def buff_stats(self, level: int):
-        stats = {
-            "health": self.health,
-            "att_damage": self.attack["damage"],
-            "bear_damage": self.ult["bear"]["damage"],
-            "bear_health": self.ult["bear"]["health"]
-        }
-
-        return super().buff_stats(stats, level)
-
-    def _spawn(self, level):
-        super()._spawn(level)
-
-        stats = self.buff_stats(level)
-
-        damage = stats["bear_damage"]
-
-        raw = damage * 0.8
-
+    def chance_calculation(self, raw: int):
         chance = random.randint(0, 10)
 
         if chance >= 9:
@@ -377,897 +264,170 @@ class Nita(Brawler):
 
         return raw
 
-    def brawler_info(
-        self,
-        brawler_name: str,
-        trophies: int = None,
-        pb: int = None,
-        rank: int = None,
-        level: int = None,
-        pp: int = None,
-        next_level_pp: int = None,
-        sp1=False,
-        sp2=False
-    ):
-        """Return embed with Brawler info."""
 
-        embed = super().brawler_info(
-            brawler_name=brawler_name, trophies=trophies, pb=pb, rank=rank,
-            level=level, pp=pp, next_level_pp=next_level_pp, sp1=sp1, sp2=sp2
-        )
+class Healer(Brawler):
+    """Class to represent a Brawler that heals using Super."""
 
-        if not level:
-            level = 1
-
-        stats = self.buff_stats(level)
-
-        embed.add_field(
-            name="HEALTH",
-            value=f"{emojis['health']} {stats['health']}"
-        )
-        embed.add_field(name="SPEED", value=f"{emojis['speed']} {self.speed}")
-
-        attack_desc = f"```{self.attack['desc']}```"
-        attack_str = (
-            attack_desc
-            + f"\n{emojis['damage']} Damage: {stats['att_damage']}"
-        )
-        embed.add_field(name="ATTACK", value=attack_str, inline=False)
-
-        super_desc = f"```{self.ult['desc']}```"
-        super_str = super_desc + (
-            f"\n{emojis['super']} Bear Damage: {stats['bear_damage']}"
-            f"\n{emojis['superhealth']} Bear Health: {stats['bear_health']}"
-        )
-
-        embed.add_field(name="SUPER", value=super_str, inline=False)
-
-        u1 = u2 = ""
-
-        if sp1:
-            u1 = " [Owned]"
-        if sp2:
-            u2 = " [Owned]"
-
-        sp_str = (
-            f"{sp_icons[brawler_name][0]} **{self.sp1['name']}**{u1}"
-            f"\n```k\n{self.sp1['desc']}```\n{sp_icons[brawler_name][1]}"
-            f" **{self.sp2['name']}**{u2}\n```k\n{self.sp2['desc']}```"
-        )
-
-        embed.add_field(name="STAR POWERS", value=sp_str, inline=False)
-
-        return embed
-
-
-class Colt(Brawler):
-    """A class to represent Colt."""
-
-    def _attack(self, level):
-        """Represent the attack ability of Colt."""
-
-        # getting all values
-        # att_range = self.attack["range"]
-        # att_reload = self.attack["reload"]
-        projectiles = self.attack["projectiles"]
-
-        stats = self.buff_stats(level)
-
-        damage = stats['att_damage']
-
-        raw = damage * projectiles * 0.8
-
-        chance = random.randint(0, 10)
-
-        if chance >= 9:
-            return raw
-        elif chance >= 6:
-            return raw * 0.7
-        elif chance >= 4:
-            return raw * 0.5
-        elif chance >= 2:
-            return raw * 0.3
-        else:
-            return 0
-
-    def _ult(self, level):
-        """Represent the Super ability of Colt."""
-
-        # getting all values
-        # ult_range = self.ult["range"]
-        projectiles = self.ult["projectiles"]
-
-        stats = self.buff_stats(level)
-
-        damage = stats['ult_damage']
-
-        raw = damage * projectiles * 0.8
-
-        chance = random.randint(0, 10)
-
-        if chance >= 9:
-            return raw, None
-        elif chance >= 6:
-            return raw * 0.7, None
-        elif chance >= 4:
-            return raw * 0.5, None
-        elif chance >= 2:
-            return raw * 0.3, None
-        else:
-            return 0, None
-
-    def buff_stats(self, level: int):
-        stats = {
+    def init(self):
+        self.stats = {
             "health": self.health,
             "att_damage": self.attack["damage"],
-            "ult_damage": self.ult["damage"]
+            "ult_heal": self.ult["heal"]
         }
 
-        return super().buff_stats(stats, level)
-
-    def brawler_info(
-        self,
-        brawler_name: str,
-        trophies: int = None,
-        pb: int = None,
-        rank: int = None,
-        level: int = None,
-        pp: int = None,
-        next_level_pp: int = None,
-        sp1=False,
-        sp2=False
-    ):
-        """Return embed with Brawler info."""
-
-        embed = super().brawler_info(
-            brawler_name=brawler_name, trophies=trophies, pb=pb, rank=rank,
-            level=level, pp=pp, next_level_pp=next_level_pp, sp1=sp1, sp2=sp2
-        )
-
-        if not level:
-            level = 1
-
-        stats = self.buff_stats(level)
-
-        embed.add_field(
-            name="HEALTH",
-            value=f"{emojis['health']} {stats['health']}"
-        )
-        embed.add_field(name="SPEED", value=f"{emojis['speed']} {self.speed}")
-
-        attack_desc = f"```{self.attack['desc']}```"
-        attack_str = (
-            attack_desc
-            + f"\n{emojis['damage']} Damage per bullet: {stats['att_damage']}"
-        )
-        embed.add_field(name="ATTACK", value=attack_str, inline=False)
-
-        super_desc = f"```{self.ult['desc']}```"
-        super_str = (
-            super_desc
-            + f"\n{emojis['super']} Damage per bullet: {stats['ult_damage']}"
-        )
-        embed.add_field(name="SUPER", value=super_str, inline=False)
-
-        u1 = u2 = ""
-
-        if sp1:
-            u1 = " [Owned]"
-        if sp2:
-            u2 = " [Owned]"
-
-        sp_str = (
-            f"{sp_icons[brawler_name][0]} **{self.sp1['name']}**{u1}"
-            f"\n```k\n{self.sp1['desc']}```\n{sp_icons[brawler_name][1]}"
-            f" **{self.sp2['name']}**{u2}\n```k\n{self.sp2['desc']}```"
-        )
-
-        embed.add_field(name="STAR POWERS", value=sp_str, inline=False)
-
-        return embed
-
-
-class Bull(Brawler):
-    """A class to represent Bull."""
-
-    def _attack(self, level):
-        """Represent the attack ability of Bull."""
-
-        # getting all values
-        # att_range = self.attack["range"]
-        # att_reload = self.attack["reload"]
-        projectiles = self.attack["projectiles"]
-
-        stats = self.buff_stats(level)
-
-        damage = stats['att_damage']
-
-        raw = damage * projectiles * 0.8
-
-        chance = random.randint(0, 10)
-
-        if chance >= 9:
-            return raw
-        elif chance >= 6:
-            return raw * 0.7
-        elif chance >= 4:
-            return raw * 0.5
-        elif chance >= 2:
-            return raw * 0.3
-        else:
-            return 0
-
     def _ult(self, level):
-        """Represent the Super ability of Bull."""
+        """Represents the Super ability of Poco."""
 
         # getting all values
         # ult_range = self.ult["range"]
 
         stats = self.buff_stats(level)
 
-        damage = stats['ult_damage']
+        heal = stats['heal']
 
-        raw = damage * 0.8
+        raw = heal * 0.8
 
-        chance = random.randint(0, 10)
+        return [self.chance_calculation(raw)], None
 
-        if chance >= 9:
-            return raw, None
-        elif chance >= 6:
-            return raw * 0.7, None
-        elif chance >= 4:
-            return raw * 0.5, None
-        elif chance >= 2:
-            return raw * 0.3, None
-        else:
-            return 0, None
-
-    def buff_stats(self, level: int):
-        stats = {
-            "health": self.health,
-            "att_damage": self.attack["damage"],
-            "ult_damage": self.ult["damage"]
-        }
-
-        return super().buff_stats(stats, level)
-
-    def brawler_info(
-        self,
-        brawler_name: str,
-        trophies: int = None,
-        pb: int = None,
-        rank: int = None,
-        level: int = None,
-        pp: int = None,
-        next_level_pp: int = None,
-        sp1=False,
-        sp2=False
-    ):
-        """Return embed with Brawler info."""
-
-        embed = super().brawler_info(
-            brawler_name=brawler_name, trophies=trophies, pb=pb, rank=rank,
-            level=level, pp=pp, next_level_pp=next_level_pp, sp1=sp1, sp2=sp2
-        )
-
-        if not level:
-            level = 1
-
-        stats = self.buff_stats(level)
-
-        embed.add_field(
-            name="HEALTH",
-            value=f"{emojis['health']} {stats['health']}"
-        )
-        embed.add_field(name="SPEED", value=f"{emojis['speed']} {self.speed}")
-
-        attack_desc = f"```{self.attack['desc']}```"
-        attack_str = (
-            attack_desc
-            + f"\n{emojis['damage']} Damage per shell: {stats['att_damage']}"
-        )
-        embed.add_field(name="ATTACK", value=attack_str, inline=False)
+    def super_info(self, stats: dict):
+        try:
+            super_str = self.ult['extra']
+        except KeyError:
+            super_str = "Heal"
 
         super_desc = f"```{self.ult['desc']}```"
-        super_str = (
-            super_desc
-            + f"\n{emojis['super']} Damage: {stats['ult_damage']}"
-        )
-        embed.add_field(name="SUPER", value=super_str, inline=False)
+        info = f"{super_desc}\n{emojis['superhealth']} {super_str}: {stats['ult_heal']}"
 
-        u1 = u2 = ""
-
-        if sp1:
-            u1 = " [Owned]"
-        if sp2:
-            u2 = " [Owned]"
-
-        sp_str = (
-            f"{sp_icons[brawler_name][0]} **{self.sp1['name']}**{u1}"
-            f"\n```k\n{self.sp1['desc']}```\n{sp_icons[brawler_name][1]}"
-            f" **{self.sp2['name']}**{u2}\n```k\n{self.sp2['desc']}```"
-        )
-
-        embed.add_field(name="STAR POWERS", value=sp_str, inline=False)
-
-        return embed
+        return info
 
 
-class Jessie(Brawler):
-    """A class to represent Jessie."""
+class Spawner(Brawler):
+    """Class to represent a Brawler that spawns a character."""
 
-    def _attack(self, level):
-        """Represent the attack ability of Jessie. """
-
-        # getting all values
-        # att_range = self.attack["range"]
-        # att_reload = self.attack["reload"]
-        projectiles = self.attack["projectiles"]
-
-        stats = self.buff_stats(level)
-
-        damage = stats['att_damage']
-
-        raw = damage * projectiles * 0.8
-
-        chance = random.randint(0, 10)
-
-        if chance >= 9:
-            return raw
-        elif chance >= 6:
-            return raw * 0.7
-        elif chance >= 4:
-            return raw * 0.5
-        elif chance >= 2:
-            return raw * 0.3
-        else:
-            return 0
+    def init(self):
+        self.stats = {
+            "health": self.health,
+            "att_damage": self.attack["damage"],
+            "spawn_damage": self.ult["spawn"]["damage"],
+            "spawn_health": self.ult["spawn"]["health"]
+        }
 
     def _ult(self, level):
-        """Represent the Super ability of Jessie."""
+        """Represents the Super ability of Nita."""
 
         # getting all values
-        # scrappy = self.ult["scrappy"]
-        # br_range = scrappy["range"]
-        # speed = scrappy["speed"]
 
         stats = self.buff_stats(level)
 
-        damage = stats["scrappy_damage"]
-        health = stats["scrappy_health"]
+        damage = stats["spawn_damage"]
+        health = stats["spawn_health"]
 
         raw = damage * 0.8
 
-        chance = random.randint(0, 10)
-
-        if chance >= 9:
-            raw *= 1
-        elif chance >= 6:
-            raw *= 0.7
-        elif chance >= 4:
-            raw *= 0.5
-        elif chance >= 2:
-            raw *= 0.3
-        else:
-            raw = 0
-
-        return raw, health
-
-    def buff_stats(self, level: int):
-        stats = {
-            "health": self.health,
-            "att_damage": self.attack["damage"],
-            "scrappy_damage": self.ult["scrappy"]["damage"],
-            "scrappy_health": self.ult["scrappy"]["health"]
-        }
-
-        return super().buff_stats(stats, level)
+        return self.chance_calculation(raw), health
 
     def _spawn(self, level):
-        super()._spawn(level)
+        """Represents the move of the spawned character of the Brawler."""
 
         stats = self.buff_stats(level)
 
-        damage = stats["scrappy_damage"]
+        damage = stats["spawn_damage"]
 
         raw = damage * 0.8
 
-        chance = random.randint(0, 10)
+        return self.chance_calculation(raw)
 
-        if chance >= 9:
-            raw *= 1
-        elif chance >= 6:
-            raw *= 0.7
-        elif chance >= 4:
-            raw *= 0.5
-        elif chance >= 2:
-            raw *= 0.3
-        else:
-            raw = 0
-
-        return raw
-
-    def brawler_info(
-        self,
-        brawler_name: str,
-        trophies: int = None,
-        pb: int = None,
-        rank: int = None,
-        level: int = None,
-        pp: int = None,
-        next_level_pp: int = None,
-        sp1=False,
-        sp2=False
-    ):
-        """Return embed with Brawler info."""
-
-        embed = super().brawler_info(
-            brawler_name=brawler_name, trophies=trophies, pb=pb, rank=rank,
-            level=level, pp=pp, next_level_pp=next_level_pp, sp1=sp1, sp2=sp2
-        )
-
-        if not level:
-            level = 1
-
-        stats = self.buff_stats(level)
-
-        embed.add_field(
-            name="HEALTH",
-            value=f"{emojis['health']} {stats['health']}"
-        )
-        embed.add_field(name="SPEED", value=f"{emojis['speed']} {self.speed}")
-
-        attack_desc = f"```{self.attack['desc']}```"
-        attack_str = (
-            attack_desc
-            + f"\n{emojis['damage']} Damage: {stats['att_damage']}"
-        )
-        embed.add_field(name="ATTACK", value=attack_str, inline=False)
+    def super_info(self, stats):
+        try:
+            super_str = self.ult['extra']
+        except KeyError:
+            super_str = "Damage"
 
         super_desc = f"```{self.ult['desc']}```"
-        super_str = super_desc + (
-            f"\n{emojis['super']} Scrappy Damage: {stats['scrappy_damage']}"
-            f"\n{emojis['superhealth']} Scrappy Health:"
-            f" {stats['scrappy_health']}"
+
+        info = (
+            "{desc}\n{att_emote} {spawn} {extra}: {damage}"
+            "\n{health_emote} {spawn} Health: {health}"
+        ).format(
+            desc=super_desc,
+            att_emote=emojis['super'],
+            spawn=self.ult['spawn']['name'],
+            extra=super_str,
+            damage=stats['spawn_damage'],
+            health_emote=emojis['superhealth'],
+            health=stats['spawn_health']
         )
 
-        embed.add_field(name="SUPER", value=super_str, inline=False)
-
-        u1 = u2 = ""
-
-        if sp1:
-            u1 = " [Owned]"
-        if sp2:
-            u2 = " [Owned]"
-
-        sp_str = (
-            f"{sp_icons[brawler_name][0]} **{self.sp1['name']}**{u1}"
-            f"\n```k\n{self.sp1['desc']}```\n{sp_icons[brawler_name][1]}"
-            f" **{self.sp2['name']}**{u2}\n```k\n{self.sp2['desc']}```"
-        )
-
-        embed.add_field(name="STAR POWERS", value=sp_str, inline=False)
-
-        return embed
+        return info
 
 
-class Brock(Brawler):
-    """A class to represent Brock."""
+class HealSpawner(Brawler):
+    """Class to represent Brawlers whose spanws heal.
 
-    def _attack(self, level):
-        """Represent the attack ability of Brock."""
+    This exists as a separate class because of the additional "spawn_heal" element.
+    """
 
-        # getting all values
-        # att_range = self.attack["range"]
-        # att_reload = self.attack["reload"]
-        projectiles = self.attack["projectiles"]
-
-        stats = self.buff_stats(level)
-
-        damage = stats['att_damage']
-
-        raw = damage * projectiles * 0.8
-
-        chance = random.randint(0, 10)
-
-        if chance >= 9:
-            return raw
-        elif chance >= 6:
-            return raw * 0.7
-        elif chance >= 4:
-            return raw * 0.5
-        elif chance >= 2:
-            return raw * 0.3
-        else:
-            return 0
-
-    def _ult(self, level):
-        """Represent the Super ability of Brock."""
-
-        # getting all values
-        # ult_range = self.ult["range"]
-        _projectiles = self.ult["projectiles"]
-        # can deal too much damage otherwise
-        projectiles = random.randint(1, _projectiles)
-
-        stats = self.buff_stats(level)
-
-        damage = stats['ult_damage']
-
-        raw = damage * projectiles * 0.8
-
-        chance = random.randint(0, 10)
-
-        if chance >= 9:
-            return raw, None
-        elif chance >= 6:
-            return raw * 0.7, None
-        elif chance >= 4:
-            return raw * 0.5, None
-        elif chance >= 2:
-            return raw * 0.3, None
-        else:
-            return 0, None
-
-    def buff_stats(self, level: int):
-        stats = {
+    def init(self):
+        self.stats = {
             "health": self.health,
             "att_damage": self.attack["damage"],
-            "ult_damage": self.ult["damage"]
+            "spawn_heal": self.ult["spawn"]["heal"],
+            "spawn_health": self.ult["spawn"]["health"]
         }
-
-        return super().buff_stats(stats, level)
-
-    def brawler_info(
-        self,
-        brawler_name: str,
-        trophies: int = None,
-        pb: int = None,
-        rank: int = None,
-        level: int = None,
-        pp: int = None,
-        next_level_pp: int = None,
-        sp1=False,
-        sp2=False
-    ):
-        """Return embed with Brawler info."""
-
-        embed = super().brawler_info(
-            brawler_name=brawler_name, trophies=trophies, pb=pb, rank=rank,
-            level=level, pp=pp, next_level_pp=next_level_pp, sp1=sp1, sp2=sp2
-        )
-
-        if not level:
-            level = 1
-
-        stats = self.buff_stats(level)
-
-        embed.add_field(
-            name="HEALTH",
-            value=f"{emojis['health']} {stats['health']}"
-        )
-        embed.add_field(name="SPEED", value=f"{emojis['speed']} {self.speed}")
-
-        attack_desc = f"```{self.attack['desc']}```"
-        attack_str = (
-            attack_desc
-            + f"\n{emojis['damage']} Damage: {stats['att_damage']}"
-        )
-        embed.add_field(name="ATTACK", value=attack_str, inline=False)
-
-        super_desc = f"```{self.ult['desc']}```"
-        super_str = (
-            super_desc
-            + f"\n{emojis['super']} Damage per rocket: {stats['ult_damage']}"
-        )
-        embed.add_field(name="SUPER", value=super_str, inline=False)
-
-        u1 = u2 = ""
-
-        if sp1:
-            u1 = " [Owned]"
-        if sp2:
-            u2 = " [Owned]"
-
-        sp_str = (
-            f"{sp_icons[brawler_name][0]} **{self.sp1['name']}**{u1}"
-            f"\n```k\n{self.sp1['desc']}```\n{sp_icons[brawler_name][1]}"
-            f" **{self.sp2['name']}**{u2}\n```k\n{self.sp2['desc']}```"
-        )
-
-        embed.add_field(name="STAR POWERS", value=sp_str, inline=False)
-
-        return embed
-
-
-class Dynamike(Brawler):
-    """A class to represent Dynamike."""
-
-    def _attack(self, level):
-        """Represent the attack ability of Dynamike."""
-
-        # getting all values
-        # att_range = self.attack["range"]
-        # att_reload = self.attack["reload"]
-        projectiles = self.attack["projectiles"]
-
-        stats = self.buff_stats(level)
-
-        damage = stats['att_damage']
-
-        raw = damage * projectiles * 0.8
-
-        chance = random.randint(0, 10)
-
-        if chance >= 9:
-            return raw
-        elif chance >= 6:
-            return raw * 0.7
-        elif chance >= 4:
-            return raw * 0.5
-        elif chance >= 2:
-            return raw * 0.3
-        else:
-            return 0
 
     def _ult(self, level):
-        """Represent the Super ability of Dynamike."""
+        """Represents the Super ability of Nita."""
 
         # getting all values
-        # ult_range = self.ult["range"]
-        projectiles = self.ult["projectiles"]
 
         stats = self.buff_stats(level)
 
-        damage = stats['ult_damage']
+        heal = stats["spawn_heal"]
+        health = stats["spawn_health"]
 
-        raw = damage * projectiles * 0.8
+        raw = heal * 0.8
 
-        chance = random.randint(0, 10)
+        return self.chance_calculation(raw), health
 
-        if chance >= 9:
-            return raw, None
-        elif chance >= 6:
-            return raw * 0.7, None
-        elif chance >= 4:
-            return raw * 0.5, None
-        elif chance >= 2:
-            return raw * 0.3, None
-        else:
-            return 0, None
+    def _spawn(self, level):
+        """Represents the move of the spawned character of Pam."""
 
-    def buff_stats(self, level: int):
-        stats = {
-            "health": self.health,
-            "att_damage": self.attack["damage"],
-            "ult_damage": self.ult["damage"]
-        }
+        heal = self.buff_stat(self.ult["spawn"]["heal"], level)
 
-        return super().buff_stats(stats, level)
+        raw = heal * 0.8
 
-    def brawler_info(
-        self,
-        brawler_name: str,
-        trophies: int = None,
-        pb: int = None,
-        rank: int = None,
-        level: int = None,
-        pp: int = None,
-        next_level_pp: int = None,
-        sp1=False,
-        sp2=False
-    ):
-        """Return embed with Brawler info."""
+        return [self.chance_calculation(raw)]
 
-        embed = super().brawler_info(
-            brawler_name=brawler_name, trophies=trophies, pb=pb, rank=rank,
-            level=level, pp=pp, next_level_pp=next_level_pp, sp1=sp1, sp2=sp2
-        )
-
-        if not level:
-            level = 1
-
-        stats = self.buff_stats(level)
-
-        embed.add_field(
-            name="HEALTH",
-            value=f"{emojis['health']} {stats['health']}"
-        )
-        embed.add_field(name="SPEED", value=f"{emojis['speed']} {self.speed}")
-
-        attack_desc = f"```{self.attack['desc']}```"
-        attack_str = (
-            attack_desc
-            + f"\n{emojis['damage']} Damage per"
-            + f" dynamite: {stats['att_damage']}"
-        )
-        embed.add_field(name="ATTACK", value=attack_str, inline=False)
+    def super_info(self, stats):
+        try:
+            super_str = self.ult['extra']
+        except KeyError:
+            super_str = "Heal"
 
         super_desc = f"```{self.ult['desc']}```"
-        super_str = (
-            super_desc
-            + f"\n{emojis['super']} Damage: {stats['ult_damage']}"
-        )
-        embed.add_field(name="SUPER", value=super_str, inline=False)
 
-        u1 = u2 = ""
-
-        if sp1:
-            u1 = " [Owned]"
-        if sp2:
-            u2 = " [Owned]"
-
-        sp_str = (
-            f"{sp_icons[brawler_name][0]} **{self.sp1['name']}**{u1}"
-            f"\n```k\n{self.sp1['desc']}```\n{sp_icons[brawler_name][1]}"
-            f" **{self.sp2['name']}**{u2}\n```k\n{self.sp2['desc']}```"
+        info = (
+            "{desc}\n{att_emote} {spawn} {extra}: {damage}"
+            "\n{health_emote} {spawn} Health: {health}"
+        ).format(
+            desc=super_desc,
+            att_emote=emojis['super'],
+            spawn=self.ult['spawn']['name'],
+            extra=super_str,
+            damage=stats['spawn_heal'],
+            health_emote=emojis['superhealth'],
+            health=stats['spawn_health']
         )
 
-        embed.add_field(name="STAR POWERS", value=sp_str, inline=False)
-
-        return embed
+        return info
 
 
-class ElPrimo(Brawler):
-    """A class to represent El Primo."""
+# SPECIAL BRAWLER CLASSES
+# These override at least one base method. They also inherit from the base `Brawler` class.
 
-    def _attack(self, level):
-        """Represent the attack ability of El Primo."""
-
-        # getting all values
-        # att_range = self.attack["range"]
-        # att_reload = self.attack["reload"]
-        projectiles = self.attack["projectiles"]
-
-        stats = self.buff_stats(level)
-
-        damage = stats['att_damage']
-
-        raw = damage * projectiles * 0.8
-
-        chance = random.randint(0, 10)
-
-        if chance >= 9:
-            return raw
-        elif chance >= 6:
-            return raw * 0.7
-        elif chance >= 4:
-            return raw * 0.5
-        elif chance >= 2:
-            return raw * 0.3
-        else:
-            return 0
-
-    def _ult(self, level):
-        """Represent the Super ability of El Primo."""
-
-        # getting all values
-        # ult_range = self.ult["range"]
-
-        stats = self.buff_stats(level)
-
-        damage = stats['ult_damage']
-
-        raw = damage * 0.8
-
-        chance = random.randint(0, 10)
-
-        if chance >= 9:
-            return raw, None
-        elif chance >= 6:
-            return raw * 0.7, None
-        elif chance >= 4:
-            return raw * 0.5, None
-        elif chance >= 2:
-            return raw * 0.3, None
-        else:
-            return 0, None
-
-    def buff_stats(self, level: int):
-        stats = {
-            "health": self.health,
-            "att_damage": self.attack["damage"],
-            "ult_damage": self.ult["damage"]
-        }
-
-        return super().buff_stats(stats, level)
-
-    def brawler_info(
-        self,
-        brawler_name: str,
-        trophies: int = None,
-        pb: int = None,
-        rank: int = None,
-        level: int = None,
-        pp: int = None,
-        next_level_pp: int = None,
-        sp1=False,
-        sp2=False
-    ):
-        """Return embed with Brawler info."""
-
-        embed = super().brawler_info(
-            brawler_name=brawler_name, trophies=trophies, pb=pb, rank=rank,
-            level=level, pp=pp, next_level_pp=next_level_pp, sp1=sp1, sp2=sp2
-        )
-
-        if not level:
-            level = 1
-
-        stats = self.buff_stats(level)
-
-        embed.add_field(
-            name="HEALTH",
-            value=f"{emojis['health']} {stats['health']}"
-        )
-        embed.add_field(name="SPEED", value=f"{emojis['speed']} {self.speed}")
-
-        attack_desc = f"```{self.attack['desc']}```"
-        attack_str = (
-            attack_desc
-            + f"\n{emojis['damage']} Damage per punch: {stats['att_damage']}"
-        )
-        embed.add_field(name="ATTACK", value=attack_str, inline=False)
-
-        super_desc = f"```{self.ult['desc']}```"
-        super_str = (
-            super_desc
-            + f"\n{emojis['super']} Damage: {stats['ult_damage']}"
-        )
-        embed.add_field(name="SUPER", value=super_str, inline=False)
-
-        u1 = u2 = ""
-
-        if sp1:
-            u1 = " [Owned]"
-        if sp2:
-            u2 = " [Owned]"
-
-        sp_str = (
-            f"{sp_icons[brawler_name][0]} **{self.sp1['name']}**{u1}"
-            f"\n```k\n{self.sp1['desc']}```\n{sp_icons[brawler_name][1]}"
-            f" **{self.sp2['name']}**{u2}\n```k\n{self.sp2['desc']}```"
-        )
-
-        embed.add_field(name="STAR POWERS", value=sp_str, inline=False)
-
-        return embed
-
-
+# Overrides `_ult` method to factor in damage over time.
 class Barley(Brawler):
-    """A class to represent Barley."""
-
-    def _attack(self, level):
-        """Represent the attack ability of Barley."""
-
-        # getting all values
-        # att_range = self.attack["range"]
-        # att_reload = self.attack["reload"]
-        projectiles = self.attack["projectiles"]
-
-        # Barley special -- damage over time
-        duration = 0.3
-
-        stats = self.buff_stats(level)
-
-        damage = stats['att_damage']
-        # damage over time
-        damage += damage * duration
-
-        raw = damage * projectiles * 0.8
-
-        chance = random.randint(0, 10)
-
-        if chance >= 9:
-            return raw
-        elif chance >= 6:
-            return raw * 0.7
-        elif chance >= 4:
-            return raw * 0.5
-        elif chance >= 2:
-            return raw * 0.3
-        else:
-            return 0
+    """Class to represent Barley."""
 
     def _ult(self, level):
         """Represent the Super ability of Barley."""
@@ -1282,658 +442,17 @@ class Barley(Brawler):
         stats = self.buff_stats(level)
 
         damage = stats['ult_damage']
-        # damage over time
+        # Damage over time
         damage += damage * duration
 
         raw = damage * projectiles * 0.8
 
-        chance = random.randint(0, 10)
+        return self.chance_calculation(raw), None
 
-        if chance >= 9:
-            return raw, None
-        elif chance >= 6:
-            return raw * 0.7, None
-        elif chance >= 4:
-            return raw * 0.5, None
-        elif chance >= 2:
-            return raw * 0.3, None
-        else:
-            return 0, None
 
-    def buff_stats(self, level: int):
-        stats = {
-            "health": self.health,
-            "att_damage": self.attack["damage"],
-            "ult_damage": self.ult["damage"]
-        }
-
-        return super().buff_stats(stats, level)
-
-    def brawler_info(
-        self,
-        brawler_name: str,
-        trophies: int = None,
-        pb: int = None,
-        rank: int = None,
-        level: int = None,
-        pp: int = None,
-        next_level_pp: int = None,
-        sp1=False,
-        sp2=False
-    ):
-        """Return embed with Brawler info."""
-
-        embed = super().brawler_info(
-            brawler_name=brawler_name, trophies=trophies, pb=pb, rank=rank,
-            level=level, pp=pp, next_level_pp=next_level_pp, sp1=sp1, sp2=sp2
-        )
-
-        if not level:
-            level = 1
-
-        stats = self.buff_stats(level)
-
-        embed.add_field(
-            name="HEALTH",
-            value=f"{emojis['health']} {stats['health']}"
-        )
-        embed.add_field(name="SPEED", value=f"{emojis['speed']} {self.speed}")
-
-        attack_desc = f"```{self.attack['desc']}```"
-        attack_str = (
-            attack_desc
-            + f"\n{emojis['damage']} Damage per second: {stats['att_damage']}"
-        )
-        embed.add_field(name="ATTACK", value=attack_str, inline=False)
-
-        super_desc = f"```{self.ult['desc']}```"
-        super_str = (
-            super_desc
-            + f"\n{emojis['super']} Damage per second: {stats['ult_damage']}"
-        )
-        embed.add_field(name="SUPER", value=super_str, inline=False)
-
-        u1 = u2 = ""
-
-        if sp1:
-            u1 = " [Owned]"
-        if sp2:
-            u2 = " [Owned]"
-
-        sp_str = (
-            f"{sp_icons[brawler_name][0]} **{self.sp1['name']}**{u1}"
-            f"\n```k\n{self.sp1['desc']}```\n{sp_icons[brawler_name][1]}"
-            f" **{self.sp2['name']}**{u2}\n```k\n{self.sp2['desc']}```"
-        )
-
-        embed.add_field(name="STAR POWERS", value=sp_str, inline=False)
-
-        return embed
-
-
-class Poco(Brawler):
-    """A class to represent Poco."""
-
-    def _attack(self, level):
-        """Represent the attack ability of Poco."""
-
-        # getting all values
-        # att_range = self.attack["range"]
-        # att_reload = self.attack["reload"]
-        projectiles = self.attack["projectiles"]
-
-        stats = self.buff_stats(level)
-
-        damage = stats['att_damage']
-
-        raw = damage * projectiles * 0.8
-
-        chance = random.randint(0, 10)
-
-        if chance >= 9:
-            return raw
-        elif chance >= 6:
-            return raw * 0.7
-        elif chance >= 4:
-            return raw * 0.5
-        elif chance >= 2:
-            return raw * 0.3
-        else:
-            return 0
-
-    def _ult(self, level):
-        """Represent the Super ability of Poco."""
-
-        # getting all values
-        # ult_range = self.ult["range"]
-
-        stats = self.buff_stats(level)
-
-        heal = stats['heal']
-
-        raw = heal * 0.8
-
-        chance = random.randint(0, 10)
-
-        # return raw as a list for healing
-        if chance >= 9:
-            return [raw], None
-        elif chance >= 6:
-            return [raw * 0.7], None
-        elif chance >= 4:
-            return [raw * 0.5], None
-        elif chance >= 2:
-            return [raw * 0.3], None
-        else:
-            return [0], None
-
-    def buff_stats(self, level: int):
-        stats = {
-            "health": self.health,
-            "att_damage": self.attack["damage"],
-            "heal": self.ult["heal"]
-        }
-
-        return super().buff_stats(stats, level)
-
-    def brawler_info(
-        self,
-        brawler_name: str,
-        trophies: int = None,
-        pb: int = None,
-        rank: int = None,
-        level: int = None,
-        pp: int = None,
-        next_level_pp: int = None,
-        sp1=False,
-        sp2=False
-    ):
-        """Return embed with Brawler info."""
-
-        embed = super().brawler_info(
-            brawler_name=brawler_name, trophies=trophies, pb=pb, rank=rank,
-            level=level, pp=pp, next_level_pp=next_level_pp, sp1=sp1, sp2=sp2
-        )
-
-        if not level:
-            level = 1
-
-        stats = self.buff_stats(level)
-
-        embed.add_field(
-            name="HEALTH",
-            value=f"{emojis['health']} {stats['health']}"
-        )
-        embed.add_field(name="SPEED", value=f"{emojis['speed']} {self.speed}")
-
-        attack_desc = f"```{self.attack['desc']}```"
-        attack_str = (
-            attack_desc
-            + f"\n{emojis['damage']} Damage: {stats['att_damage']}"
-        )
-        embed.add_field(name="ATTACK", value=attack_str, inline=False)
-
-        super_desc = f"```{self.ult['desc']}```"
-        super_str = super_desc + f"\n{emojis['health']} Heal: {stats['heal']}"
-        embed.add_field(name="SUPER", value=super_str, inline=False)
-
-        u1 = u2 = ""
-
-        if sp1:
-            u1 = " [Owned]"
-        if sp2:
-            u2 = " [Owned]"
-
-        sp_str = (
-            f"{sp_icons[brawler_name][0]} **{self.sp1['name']}**{u1}"
-            f"\n```k\n{self.sp1['desc']}```\n{sp_icons[brawler_name][1]}"
-            f" **{self.sp2['name']}**{u2}\n```k\n{self.sp2['desc']}```"
-        )
-
-        embed.add_field(name="STAR POWERS", value=sp_str, inline=False)
-
-        return embed
-
-
-class Rico(Brawler):
-    """A class to represent Rico."""
-
-    def _attack(self, level):
-        """Represent the attack ability of Rico."""
-
-        # getting all values
-        # att_range = self.attack["range"]
-        # att_reload = self.attack["reload"]
-        projectiles = self.attack["projectiles"]
-
-        stats = self.buff_stats(level)
-
-        damage = stats['att_damage']
-
-        raw = damage * projectiles * 0.8
-
-        chance = random.randint(0, 10)
-
-        if chance >= 9:
-            return raw
-        elif chance >= 6:
-            return raw * 0.7
-        elif chance >= 4:
-            return raw * 0.5
-        elif chance >= 2:
-            return raw * 0.3
-        else:
-            return 0
-
-    def _ult(self, level):
-        """Represent the Super ability of Rico."""
-
-        # getting all values
-        # ult_range = self.ult["range"]
-        projectiles = self.ult["projectiles"]
-
-        stats = self.buff_stats(level)
-
-        damage = stats['ult_damage']
-
-        raw = damage * projectiles * 0.8
-
-        chance = random.randint(0, 10)
-
-        if chance >= 9:
-            return raw, None
-        elif chance >= 6:
-            return raw * 0.7, None
-        elif chance >= 4:
-            return raw * 0.5, None
-        elif chance >= 2:
-            return raw * 0.3, None
-        else:
-            return 0, None
-
-    def buff_stats(self, level: int):
-        stats = {
-            "health": self.health,
-            "att_damage": self.attack["damage"],
-            "ult_damage": self.ult["damage"]
-        }
-
-        return super().buff_stats(stats, level)
-
-    def brawler_info(
-        self,
-        brawler_name: str,
-        trophies: int = None,
-        pb: int = None,
-        rank: int = None,
-        level: int = None,
-        pp: int = None,
-        next_level_pp: int = None,
-        sp1=False,
-        sp2=False
-    ):
-        """Return embed with Brawler info."""
-
-        embed = super().brawler_info(
-            brawler_name=brawler_name, trophies=trophies, pb=pb, rank=rank,
-            level=level, pp=pp, next_level_pp=next_level_pp, sp1=sp1, sp2=sp2
-        )
-
-        if not level:
-            level = 1
-
-        stats = self.buff_stats(level)
-
-        embed.add_field(
-            name="HEALTH",
-            value=f"{emojis['health']} {stats['health']}"
-        )
-        embed.add_field(name="SPEED", value=f"{emojis['speed']} {self.speed}")
-
-        attack_desc = f"```{self.attack['desc']}```"
-        attack_str = (
-            attack_desc
-            + f"\n{emojis['damage']} Damage per bullet: {stats['att_damage']}"
-        )
-        embed.add_field(name="ATTACK", value=attack_str, inline=False)
-
-        super_desc = f"```{self.ult['desc']}```"
-        super_str = (
-            super_desc
-            + f"\n{emojis['super']} Damage per bullet: {stats['ult_damage']}"
-        )
-        embed.add_field(name="SUPER", value=super_str, inline=False)
-
-        u1 = u2 = ""
-
-        if sp1:
-            u1 = " [Owned]"
-        if sp2:
-            u2 = " [Owned]"
-
-        sp_str = (
-            f"{sp_icons[brawler_name][0]} **{self.sp1['name']}**{u1}"
-            f"\n```k\n{self.sp1['desc']}```\n{sp_icons[brawler_name][1]}"
-            f" **{self.sp2['name']}**{u2}\n```k\n{self.sp2['desc']}```"
-        )
-
-        embed.add_field(name="STAR POWERS", value=sp_str, inline=False)
-
-        return embed
-
-
-class Darryl(Brawler):
-    """A class to represent Darryl."""
-
-    def _attack(self, level):
-        """Represent the attack ability of Darryl."""
-
-        # getting all values
-        # att_range = self.attack["range"]
-        # att_reload = self.attack["reload"]
-        projectiles = self.attack["projectiles"]
-
-        stats = self.buff_stats(level)
-
-        damage = stats['att_damage']
-
-        raw = damage * projectiles * 0.8
-
-        chance = random.randint(0, 10)
-
-        if chance >= 9:
-            return raw
-        elif chance >= 6:
-            return raw * 0.7
-        elif chance >= 4:
-            return raw * 0.5
-        elif chance >= 2:
-            return raw * 0.3
-        else:
-            return 0
-
-    def _ult(self, level):
-        """Represent the Super ability of Darryl."""
-
-        # getting all values
-        # ult_range = self.ult["range"]
-
-        stats = self.buff_stats(level)
-
-        damage = stats['ult_damage']
-
-        raw = damage * 0.8
-
-        chance = random.randint(0, 10)
-
-        if chance >= 9:
-            return raw, None
-        elif chance >= 6:
-            return raw * 0.7, None
-        elif chance >= 4:
-            return raw * 0.5, None
-        elif chance >= 2:
-            return raw * 0.3, None
-        else:
-            return 0, None
-
-    def buff_stats(self, level: int):
-        stats = {
-            "health": self.health,
-            "att_damage": self.attack["damage"],
-            "ult_damage": self.ult["damage"]
-        }
-
-        return super().buff_stats(stats, level)
-
-    def brawler_info(
-        self,
-        brawler_name: str,
-        trophies: int = None,
-        pb: int = None,
-        rank: int = None,
-        level: int = None,
-        pp: int = None,
-        next_level_pp: int = None,
-        sp1=False,
-        sp2=False
-    ):
-        """Return embed with Brawler info."""
-
-        embed = super().brawler_info(
-            brawler_name=brawler_name, trophies=trophies, pb=pb, rank=rank,
-            level=level, pp=pp, next_level_pp=next_level_pp, sp1=sp1, sp2=sp2
-        )
-
-        if not level:
-            level = 1
-
-        stats = self.buff_stats(level)
-
-        embed.add_field(
-            name="HEALTH",
-            value=f"{emojis['health']} {stats['health']}"
-        )
-        embed.add_field(name="SPEED", value=f"{emojis['speed']} {self.speed}")
-
-        attack_desc = f"```{self.attack['desc']}```"
-        attack_str = (
-            attack_desc
-            + f"\n{emojis['damage']} Damage per shell: {stats['att_damage']}"
-        )
-        embed.add_field(name="ATTACK", value=attack_str, inline=False)
-
-        super_desc = f"```{self.ult['desc']}```"
-        super_str = (
-            super_desc
-            + f"\n{emojis['super']} Damage: {stats['ult_damage']}"
-        )
-        embed.add_field(name="SUPER", value=super_str, inline=False)
-
-        u1 = u2 = ""
-
-        if sp1:
-            u1 = " [Owned]"
-        if sp2:
-            u2 = " [Owned]"
-
-        sp_str = (
-            f"{sp_icons[brawler_name][0]} **{self.sp1['name']}**{u1}"
-            f"\n```k\n{self.sp1['desc']}```\n{sp_icons[brawler_name][1]}"
-            f" **{self.sp2['name']}**{u2}\n```k\n{self.sp2['desc']}```"
-        )
-
-        embed.add_field(name="STAR POWERS", value=sp_str, inline=False)
-
-        return embed
-
-
-class Penny(Brawler):
-    """A class to represent Penny."""
-
-    def _attack(self, level):
-        """Represent the attack ability of Penny."""
-
-        # getting all values
-        # att_range = self.attack["range"]
-        # att_reload = self.attack["reload"]
-        projectiles = self.attack["projectiles"]
-
-        stats = self.buff_stats(level)
-
-        damage = stats['att_damage']
-
-        raw = damage * projectiles * 0.8
-
-        chance = random.randint(0, 10)
-
-        if chance >= 9:
-            return raw
-        elif chance >= 6:
-            return raw * 0.7
-        elif chance >= 4:
-            return raw * 0.5
-        elif chance >= 2:
-            return raw * 0.3
-        else:
-            return 0
-
-    def _ult(self, level):
-        """Represent the Super ability of Penny."""
-
-        # getting all values
-        # cannon = self.ult["cannon"]
-        # br_range = cannon["range"]
-
-        stats = self.buff_stats(level)
-
-        damage = stats["cannon_damage"]
-        health = stats["cannon_health"]
-
-        raw = damage * 0.8
-
-        chance = random.randint(0, 10)
-
-        if chance >= 9:
-            raw *= 1
-        elif chance >= 6:
-            raw *= 0.7
-        elif chance >= 4:
-            raw *= 0.5
-        elif chance >= 2:
-            raw *= 0.3
-        else:
-            raw = 0
-
-        return raw, health
-
-    def buff_stats(self, level: int):
-        stats = {
-            "health": self.health,
-            "att_damage": self.attack["damage"],
-            "cannon_damage": self.ult["cannon"]["damage"],
-            "cannon_health": self.ult["cannon"]["health"]
-        }
-
-        return super().buff_stats(stats, level)
-
-    def _spawn(self, level):
-        super()._spawn(level)
-
-        stats = self.buff_stats(level)
-
-        damage = stats["cannon_damage"]
-
-        raw = damage * 0.8
-
-        chance = random.randint(0, 10)
-
-        if chance >= 9:
-            raw *= 1
-        elif chance >= 6:
-            raw *= 0.7
-        elif chance >= 4:
-            raw *= 0.5
-        elif chance >= 2:
-            raw *= 0.3
-        else:
-            raw = 0
-
-        return raw
-
-    def brawler_info(
-        self,
-        brawler_name: str,
-        trophies: int = None,
-        pb: int = None,
-        rank: int = None,
-        level: int = None,
-        pp: int = None,
-        next_level_pp: int = None,
-        sp1=False,
-        sp2=False
-    ):
-        """Return embed with Brawler info."""
-
-        embed = super().brawler_info(
-            brawler_name=brawler_name, trophies=trophies, pb=pb, rank=rank,
-            level=level, pp=pp, next_level_pp=next_level_pp, sp1=sp1, sp2=sp2
-        )
-
-        if not level:
-            level = 1
-
-        stats = self.buff_stats(level)
-
-        embed.add_field(
-            name="HEALTH",
-            value=f"{emojis['health']} {stats['health']}"
-        )
-        embed.add_field(name="SPEED", value=f"{emojis['speed']} {self.speed}")
-
-        attack_desc = f"```{self.attack['desc']}```"
-        attack_str = (
-            attack_desc
-            + f"\n{emojis['damage']} Damage: {stats['att_damage']}"
-        )
-        embed.add_field(name="ATTACK", value=attack_str, inline=False)
-
-        super_desc = f"```{self.ult['desc']}```"
-        super_str = super_desc + (
-            f"\n{emojis['super']} Cannon Damage: {stats['cannon_damage']}"
-            f"\n{emojis['superhealth']} Cannon Health:"
-            f" {stats['cannon_health']}"
-        )
-
-        embed.add_field(name="SUPER", value=super_str, inline=False)
-
-        u1 = u2 = ""
-
-        if sp1:
-            u1 = " [Owned]"
-        if sp2:
-            u2 = " [Owned]"
-
-        sp_str = (
-            f"{sp_icons[brawler_name][0]} **{self.sp1['name']}**{u1}"
-            f"\n```k\n{self.sp1['desc']}```\n{sp_icons[brawler_name][1]}"
-            f" **{self.sp2['name']}**{u2}\n```k\n{self.sp2['desc']}```"
-        )
-
-        embed.add_field(name="STAR POWERS", value=sp_str, inline=False)
-
-        return embed
-
-
+# Overrides `_ult` method to factor in spin duration.
 class Carl(Brawler):
-    """A class to represent Carl."""
-
-    def _attack(self, level):
-        """Represent the attack ability of Carl."""
-
-        # getting all values
-        # att_range = self.attack["range"]
-        # att_reload = self.attack["reload"]
-        projectiles = self.attack["projectiles"]
-
-        stats = self.buff_stats(level)
-
-        damage = stats['att_damage']
-
-        raw = damage * projectiles * 0.8
-
-        chance = random.randint(0, 10)
-
-        if chance >= 9:
-            return raw
-        elif chance >= 6:
-            return raw * 0.7
-        elif chance >= 4:
-            return raw * 0.5
-        elif chance >= 2:
-            return raw * 0.3
-        else:
-            return 0
+    """Class to represent Carl."""
 
     def _ult(self, level):
         """Represent the Super ability of Carl."""
@@ -1947,222 +466,15 @@ class Carl(Brawler):
 
         raw = damage * 0.8 * duration
 
-        chance = random.randint(0, 10)
-
-        if chance >= 9:
-            return raw, None
-        elif chance >= 6:
-            return raw * 0.7, None
-        elif chance >= 4:
-            return raw * 0.5, None
-        elif chance >= 2:
-            return raw * 0.3, None
-        else:
-            return 0, None
-
-    def buff_stats(self, level: int):
-        stats = {
-            "health": self.health,
-            "att_damage": self.attack["damage"],
-            "ult_damage": self.ult["damage"]
-        }
-
-        return super().buff_stats(stats, level)
-
-    def brawler_info(
-        self,
-        brawler_name: str,
-        trophies: int = None,
-        pb: int = None,
-        rank: int = None,
-        level: int = None,
-        pp: int = None,
-        next_level_pp: int = None,
-        sp1=False,
-        sp2=False
-    ):
-        """Return embed with Brawler info."""
-
-        embed = super().brawler_info(
-            brawler_name=brawler_name, trophies=trophies, pb=pb, rank=rank,
-            level=level, pp=pp, next_level_pp=next_level_pp, sp1=sp1, sp2=sp2
-        )
-
-        if not level:
-            level = 1
-
-        stats = self.buff_stats(level)
-
-        embed.add_field(
-            name="HEALTH",
-            value=f"{emojis['health']} {stats['health']}"
-        )
-        embed.add_field(name="SPEED", value=f"{emojis['speed']} {self.speed}")
-
-        attack_desc = f"```{self.attack['desc']}```"
-        attack_str = (
-            attack_desc
-            + f"\n{emojis['damage']} Damage on hit: {stats['att_damage']}"
-        )
-        embed.add_field(name="ATTACK", value=attack_str, inline=False)
-
-        super_desc = f"```{self.ult['desc']}```"
-        super_str = (
-            super_desc
-            + f"\n{emojis['super']} Damage per swing: {stats['ult_damage']}"
-        )
-        embed.add_field(name="SUPER", value=super_str, inline=False)
-
-        u1 = u2 = ""
-
-        if sp1:
-            u1 = " [Owned]"
-        if sp2:
-            u2 = " [Owned]"
-
-        sp_str = (
-            f"{sp_icons[brawler_name][0]} **{self.sp1['name']}**{u1}"
-            f"\n```k\n{self.sp1['desc']}```\n{sp_icons[brawler_name][1]}"
-            f" **{self.sp2['name']}**{u2}\n```k\n{self.sp2['desc']}```"
-        )
-
-        embed.add_field(name="STAR POWERS", value=sp_str, inline=False)
-
-        return embed
+        return self.chance_calculation(raw), None
 
 
-class Bo(Brawler):
-    """A class to represent Bo."""
-
-    def _attack(self, level):
-        """Represent the attack ability of Bo."""
-
-        # getting all values
-        # att_range = self.attack["range"]
-        # att_reload = self.attack["reload"]
-        projectiles = self.attack["projectiles"]
-
-        stats = self.buff_stats(level)
-
-        damage = stats['att_damage']
-
-        raw = damage * projectiles * 0.8
-
-        chance = random.randint(0, 10)
-
-        if chance >= 9:
-            return raw
-        elif chance >= 6:
-            return raw * 0.7
-        elif chance >= 4:
-            return raw * 0.5
-        elif chance >= 2:
-            return raw * 0.3
-        else:
-            return 0
-
-    def _ult(self, level):
-        """Represent the Super ability of Bo."""
-
-        # getting all values
-        # ult_range = self.ult["range"]
-        projectiles = self.ult["projectiles"]
-
-        stats = self.buff_stats(level)
-
-        damage = stats['ult_damage']
-
-        raw = damage * projectiles * 0.8
-
-        chance = random.randint(0, 10)
-
-        if chance >= 9:
-            return raw, None
-        elif chance >= 6:
-            return raw * 0.7, None
-        elif chance >= 4:
-            return raw * 0.5, None
-        elif chance >= 2:
-            return raw * 0.3, None
-        else:
-            return 0, None
-
-    def buff_stats(self, level: int):
-        stats = {
-            "health": self.health,
-            "att_damage": self.attack["damage"],
-            "ult_damage": self.ult["damage"]
-        }
-
-        return super().buff_stats(stats, level)
-
-    def brawler_info(
-        self,
-        brawler_name: str,
-        trophies: int = None,
-        pb: int = None,
-        rank: int = None,
-        level: int = None,
-        pp: int = None,
-        next_level_pp: int = None,
-        sp1=False,
-        sp2=False
-    ):
-        """Return embed with Brawler info."""
-
-        embed = super().brawler_info(
-            brawler_name=brawler_name, trophies=trophies, pb=pb, rank=rank,
-            level=level, pp=pp, next_level_pp=next_level_pp, sp1=sp1, sp2=sp2
-        )
-
-        if not level:
-            level = 1
-
-        stats = self.buff_stats(level)
-
-        embed.add_field(
-            name="HEALTH",
-            value=f"{emojis['health']} {stats['health']}"
-        )
-        embed.add_field(name="SPEED", value=f"{emojis['speed']} {self.speed}")
-
-        attack_desc = f"```{self.attack['desc']}```"
-        attack_str = (
-            attack_desc
-            + f"\n{emojis['damage']} Damage per arrow: {stats['att_damage']}"
-        )
-        embed.add_field(name="ATTACK", value=attack_str, inline=False)
-
-        super_desc = f"```{self.ult['desc']}```"
-        super_str = (
-            super_desc
-            + f"\n{emojis['super']} Damage per mine: {stats['ult_damage']}"
-        )
-        embed.add_field(name="SUPER", value=super_str, inline=False)
-
-        u1 = u2 = ""
-
-        if sp1:
-            u1 = " [Owned]"
-        if sp2:
-            u2 = " [Owned]"
-
-        sp_str = (
-            f"{sp_icons[brawler_name][0]} **{self.sp1['name']}**{u1}"
-            f"\n```k\n{self.sp1['desc']}```\n{sp_icons[brawler_name][1]}"
-            f" **{self.sp2['name']}**{u2}\n```k\n{self.sp2['desc']}```"
-        )
-
-        embed.add_field(name="STAR POWERS", value=sp_str, inline=False)
-
-        return embed
-
-
+# Overrides `_attack` method to factor in range scaling.
 class Piper(Brawler):
-    """A class to represent Piper."""
+    """Class to represent Piper."""
 
     def _attack(self, level):
-        """Represent the attack ability of Piper."""
+        """Represents the attack ability of Piper."""
 
         # getting all values
         range_ = self.attack["range"]
@@ -2177,796 +489,23 @@ class Piper(Brawler):
 
         raw = damage * projectiles * 0.8 * range_scaling
 
-        chance = random.randint(0, 10)
+        return self.chance_calculation(raw)
 
-        if chance >= 9:
-            return raw
-        elif chance >= 6:
-            return raw * 0.7
-        elif chance >= 4:
-            return raw * 0.5
-        elif chance >= 2:
-            return raw * 0.3
-        else:
-            return 0
 
-    def _ult(self, level):
-        """Represent the Super ability of Piper."""
-
-        # getting all values
-        # ult_range = self.ult["range"]
-        projectiles = self.ult["projectiles"]
-
-        stats = self.buff_stats(level)
-
-        damage = stats['ult_damage']
-
-        raw = damage * projectiles * 0.8
-
-        chance = random.randint(0, 10)
-
-        if chance >= 9:
-            return raw, None
-        elif chance >= 6:
-            return raw * 0.7, None
-        elif chance >= 4:
-            return raw * 0.5, None
-        elif chance >= 2:
-            return raw * 0.3, None
-        else:
-            return 0, None
-
-    def buff_stats(self, level: int):
-        stats = {
-            "health": self.health,
-            "att_damage": self.attack["damage"],
-            "ult_damage": self.ult["damage"]
-        }
-
-        return super().buff_stats(stats, level)
-
-    def brawler_info(
-        self,
-        brawler_name: str,
-        trophies: int = None,
-        pb: int = None,
-        rank: int = None,
-        level: int = None,
-        pp: int = None,
-        next_level_pp: int = None,
-        sp1=False,
-        sp2=False
-    ):
-        """Return embed with Brawler info."""
-
-        embed = super().brawler_info(
-            brawler_name=brawler_name, trophies=trophies, pb=pb, rank=rank,
-            level=level, pp=pp, next_level_pp=next_level_pp, sp1=sp1, sp2=sp2
-        )
-
-        if not level:
-            level = 1
-
-        stats = self.buff_stats(level)
-
-        embed.add_field(
-            name="HEALTH",
-            value=f"{emojis['health']} {stats['health']}"
-        )
-        embed.add_field(name="SPEED", value=f"{emojis['speed']} {self.speed}")
-
-        attack_desc = f"```{self.attack['desc']}```"
-        attack_str = (
-            attack_desc + (
-                f"\n{emojis['damage']} Damage at max"
-                f" range: {stats['att_damage']}"
-            )
-        )
-        embed.add_field(name="ATTACK", value=attack_str, inline=False)
-
-        super_desc = f"```{self.ult['desc']}```"
-        super_str = (
-            super_desc
-            + f"\n{emojis['super']} Damage per grenade: {stats['ult_damage']}"
-        )
-        embed.add_field(name="SUPER", value=super_str, inline=False)
-
-        u1 = u2 = ""
-
-        if sp1:
-            u1 = " [Owned]"
-        if sp2:
-            u2 = " [Owned]"
-
-        sp_str = (
-            f"{sp_icons[brawler_name][0]} **{self.sp1['name']}**{u1}"
-            f"\n```k\n{self.sp1['desc']}```\n{sp_icons[brawler_name][1]}"
-            f" **{self.sp2['name']}**{u2}\n```k\n{self.sp2['desc']}```"
-        )
-
-        embed.add_field(name="STAR POWERS", value=sp_str, inline=False)
-
-        return embed
-
-
-class Pam(Brawler):
-    """A class to represent Pam."""
-
-    def _attack(self, level):
-        """Represent the attack ability of Pam."""
-
-        # getting all values
-        # att_range = self.attack["range"]
-        # att_reload = self.attack["reload"]
-        projectiles = self.attack["projectiles"]
-
-        stats = self.buff_stats(level)
-
-        damage = stats['att_damage']
-
-        raw = damage * projectiles * 0.8
-
-        chance = random.randint(0, 10)
-
-        if chance >= 9:
-            return raw
-        elif chance >= 6:
-            return raw * 0.7
-        elif chance >= 4:
-            return raw * 0.5
-        elif chance >= 2:
-            return raw * 0.3
-        else:
-            return 0
-
-    def _ult(self, level):
-        """Represent the Super ability of Penny."""
-
-        # getting all values
-        # turret = self.ult["turret"]
-        # br_range = cannon["range"]
-
-        stats = self.buff_stats(level)
-
-        heal = stats["turret_heal"]
-        health = stats["turret_health"]
-
-        raw = heal * 0.8
-
-        chance = random.randint(0, 10)
-
-        if chance >= 9:
-            raw *= 1
-        elif chance >= 6:
-            raw *= 0.7
-        elif chance >= 4:
-            raw *= 0.5
-        elif chance >= 2:
-            raw *= 0.3
-        else:
-            raw = 0
-
-        # return raw as a list for healing
-        return [raw], health
-
-    def buff_stats(self, level: int):
-        stats = {
-            "health": self.health,
-            "att_damage": self.attack["damage"],
-            "turret_heal": self.ult["turret"]["heal"],
-            "turret_health": self.ult["turret"]["health"]
-        }
-
-        return super().buff_stats(stats, level)
-
-    def _spawn(self, level):
-        super()._spawn(level)
-
-        stats = self.buff_stats(level)
-
-        heal = stats["turret_heal"]
-
-        raw = heal * 0.8
-
-        chance = random.randint(0, 10)
-
-        if chance >= 9:
-            raw *= 1
-        elif chance >= 6:
-            raw *= 0.7
-        elif chance >= 4:
-            raw *= 0.5
-        elif chance >= 2:
-            raw *= 0.3
-        else:
-            raw = 0
-
-        return [raw]
-
-    def brawler_info(
-        self,
-        brawler_name: str,
-        trophies: int = None,
-        pb: int = None,
-        rank: int = None,
-        level: int = None,
-        pp: int = None,
-        next_level_pp: int = None,
-        sp1=False,
-        sp2=False
-    ):
-        """Return embed with Brawler info."""
-
-        embed = super().brawler_info(
-            brawler_name=brawler_name, trophies=trophies, pb=pb, rank=rank,
-            level=level, pp=pp, next_level_pp=next_level_pp, sp1=sp1, sp2=sp2
-        )
-
-        if not level:
-            level = 1
-
-        stats = self.buff_stats(level)
-
-        embed.add_field(
-            name="HEALTH",
-            value=f"{emojis['health']} {stats['health']}"
-        )
-        embed.add_field(name="SPEED", value=f"{emojis['speed']} {self.speed}")
-
-        attack_desc = f"```{self.attack['desc']}```"
-        attack_str = (
-            attack_desc
-            + f"\n{emojis['damage']} Damage per scrap: {stats['att_damage']}"
-        )
-        embed.add_field(name="ATTACK", value=attack_str, inline=False)
-
-        super_desc = f"```{self.ult['desc']}```"
-        super_str = super_desc + (
-            f"\n{emojis['super']} Turret Heal Per"
-            f" Second: {stats['turret_heal']}"
-            f"\n{emojis['superhealth']} Turret Health:"
-            f" {stats['turret_health']}"
-        )
-
-        embed.add_field(name="SUPER", value=super_str, inline=False)
-
-        u1 = u2 = ""
-
-        if sp1:
-            u1 = " [Owned]"
-        if sp2:
-            u2 = " [Owned]"
-
-        sp_str = (
-            f"{sp_icons[brawler_name][0]} **{self.sp1['name']}**{u1}"
-            f"\n```k\n{self.sp1['desc']}```\n{sp_icons[brawler_name][1]}"
-            f" **{self.sp2['name']}**{u2}\n```k\n{self.sp2['desc']}```"
-        )
-
-        embed.add_field(name="STAR POWERS", value=sp_str, inline=False)
-
-        return embed
-
-
-class Mortis(Brawler):
-    """A class to represent Mortis."""
-
-    def _attack(self, level):
-        """Represent the attack ability of Mortis."""
-
-        # getting all values
-        # range_ = self.attack["range"]
-        # att_reload = self.attack["reload"]
-        projectiles = self.attack["projectiles"]
-
-        stats = self.buff_stats(level)
-
-        damage = stats['att_damage']
-
-        raw = damage * projectiles * 0.8
-
-        chance = random.randint(0, 10)
-
-        if chance >= 9:
-            return raw
-        elif chance >= 6:
-            return raw * 0.7
-        elif chance >= 4:
-            return raw * 0.5
-        elif chance >= 2:
-            return raw * 0.3
-        else:
-            return 0
-
-    def _ult(self, level):
-        """Represent the Super ability of Mortis."""
-
-        # getting all values
-        # ult_range = self.ult["range"]
-        projectiles = self.ult["projectiles"]
-
-        stats = self.buff_stats(level)
-
-        damage = stats['ult_damage']
-
-        raw = damage * projectiles * 0.8
-
-        chance = random.randint(0, 10)
-
-        if chance >= 9:
-            return [raw], None
-        elif chance >= 6:
-            return [raw * 0.7], None
-        elif chance >= 4:
-            return [raw * 0.5], None
-        elif chance >= 2:
-            return [raw * 0.3], None
-        else:
-            return [0], None
-
-    def buff_stats(self, level: int):
-        stats = {
-            "health": self.health,
-            "att_damage": self.attack["damage"],
-            "ult_damage": self.ult["damage"]
-        }
-
-        return super().buff_stats(stats, level)
-
-    def brawler_info(
-        self,
-        brawler_name: str,
-        trophies: int = None,
-        pb: int = None,
-        rank: int = None,
-        level: int = None,
-        pp: int = None,
-        next_level_pp: int = None,
-        sp1=False,
-        sp2=False
-    ):
-        """Return embed with Brawler info."""
-
-        embed = super().brawler_info(
-            brawler_name=brawler_name, trophies=trophies, pb=pb, rank=rank,
-            level=level, pp=pp, next_level_pp=next_level_pp, sp1=sp1, sp2=sp2
-        )
-
-        if not level:
-            level = 1
-
-        stats = self.buff_stats(level)
-
-        embed.add_field(
-            name="HEALTH",
-            value=f"{emojis['health']} {stats['health']}"
-        )
-        embed.add_field(name="SPEED", value=f"{emojis['speed']} {self.speed}")
-
-        attack_desc = f"```{self.attack['desc']}```"
-        attack_str = (
-            attack_desc + (
-                f"\n{emojis['damage']} Damage: {stats['att_damage']}"
-            )
-        )
-        embed.add_field(name="ATTACK", value=attack_str, inline=False)
-
-        super_desc = f"```{self.ult['desc']}```"
-        super_str = (
-            super_desc
-            + f"\n{emojis['super']} Damage: {stats['ult_damage']}"
-        )
-        embed.add_field(name="SUPER", value=super_str, inline=False)
-
-        u1 = u2 = ""
-
-        if sp1:
-            u1 = " [Owned]"
-        if sp2:
-            u2 = " [Owned]"
-
-        sp_str = (
-            f"{sp_icons[brawler_name][0]} **{self.sp1['name']}**{u1}"
-            f"\n```k\n{self.sp1['desc']}```\n{sp_icons[brawler_name][1]}"
-            f" **{self.sp2['name']}**{u2}\n```k\n{self.sp2['desc']}```"
-        )
-
-        embed.add_field(name="STAR POWERS", value=sp_str, inline=False)
-
-        return embed
-
-
-class Frank(Brawler):
-    """A class to represent Frank."""
-
-    def _attack(self, level):
-        """Represent the attack ability of Frank."""
-
-        # getting all values
-        # att_range = self.attack["range"]
-        # att_reload = self.attack["reload"]
-        projectiles = self.attack["projectiles"]
-
-        stats = self.buff_stats(level)
-
-        damage = stats['att_damage']
-
-        raw = damage * projectiles * 0.8
-
-        chance = random.randint(0, 10)
-
-        if chance >= 9:
-            return raw
-        elif chance >= 6:
-            return raw * 0.7
-        elif chance >= 4:
-            return raw * 0.5
-        elif chance >= 2:
-            return raw * 0.3
-        else:
-            return 0
-
-    def _ult(self, level):
-        """Represent the Super ability of Frank."""
-
-        # getting all values
-        # ult_range = self.ult["range"]
-        projectiles = self.ult["projectiles"]
-
-        stats = self.buff_stats(level)
-
-        damage = stats['ult_damage']
-
-        raw = damage * projectiles * 0.8
-
-        chance = random.randint(0, 10)
-
-        if chance >= 9:
-            return raw, None
-        elif chance >= 6:
-            return raw * 0.7, None
-        elif chance >= 4:
-            return raw * 0.5, None
-        elif chance >= 2:
-            return raw * 0.3, None
-        else:
-            return 0, None
-
-    def buff_stats(self, level: int):
-        stats = {
-            "health": self.health,
-            "att_damage": self.attack["damage"],
-            "ult_damage": self.ult["damage"]
-        }
-
-        return super().buff_stats(stats, level)
-
-    def brawler_info(
-        self,
-        brawler_name: str,
-        trophies: int = None,
-        pb: int = None,
-        rank: int = None,
-        level: int = None,
-        pp: int = None,
-        next_level_pp: int = None,
-        sp1=False,
-        sp2=False
-    ):
-        """Return embed with Brawler info."""
-
-        embed = super().brawler_info(
-            brawler_name=brawler_name, trophies=trophies, pb=pb, rank=rank,
-            level=level, pp=pp, next_level_pp=next_level_pp, sp1=sp1, sp2=sp2
-        )
-
-        if not level:
-            level = 1
-
-        stats = self.buff_stats(level)
-
-        embed.add_field(
-            name="HEALTH",
-            value=f"{emojis['health']} {stats['health']}"
-        )
-        embed.add_field(name="SPEED", value=f"{emojis['speed']} {self.speed}")
-
-        attack_desc = f"```{self.attack['desc']}```"
-        attack_str = (
-            attack_desc
-            + f"\n{emojis['damage']} Damage: {stats['att_damage']}"
-        )
-        embed.add_field(name="ATTACK", value=attack_str, inline=False)
-
-        super_desc = f"```{self.ult['desc']}```"
-        super_str = (
-            super_desc
-            + f"\n{emojis['super']} Damage: {stats['ult_damage']}"
-        )
-        embed.add_field(name="SUPER", value=super_str, inline=False)
-
-        u1 = u2 = ""
-
-        if sp1:
-            u1 = " [Owned]"
-        if sp2:
-            u2 = " [Owned]"
-
-        sp_str = (
-            f"{sp_icons[brawler_name][0]} **{self.sp1['name']}**{u1}"
-            f"\n```k\n{self.sp1['desc']}```\n{sp_icons[brawler_name][1]}"
-            f" **{self.sp2['name']}**{u2}\n```k\n{self.sp2['desc']}```"
-        )
-
-        embed.add_field(name="STAR POWERS", value=sp_str, inline=False)
-
-        return embed
-
-
-class Tara(Brawler):
-    """A class to represent Tara."""
-
-    def _attack(self, level):
-        """Represent the attack ability of Tara."""
-
-        # getting all values
-        # att_range = self.attack["range"]
-        # att_reload = self.attack["reload"]
-        projectiles = self.attack["projectiles"]
-
-        stats = self.buff_stats(level)
-
-        damage = stats['att_damage']
-
-        raw = damage * projectiles * 0.8
-
-        chance = random.randint(0, 10)
-
-        if chance >= 9:
-            return raw
-        elif chance >= 6:
-            return raw * 0.7
-        elif chance >= 4:
-            return raw * 0.5
-        elif chance >= 2:
-            return raw * 0.3
-        else:
-            return 0
-
-    def _ult(self, level):
-        """Represent the Super ability of Tara."""
-
-        # getting all values
-        # ult_range = self.ult["range"]
-        projectiles = self.ult["projectiles"]
-
-        stats = self.buff_stats(level)
-
-        damage = stats['ult_damage']
-
-        raw = damage * projectiles * 0.8
-
-        chance = random.randint(0, 10)
-
-        if chance >= 9:
-            return raw, None
-        elif chance >= 6:
-            return raw * 0.7, None
-        elif chance >= 4:
-            return raw * 0.5, None
-        elif chance >= 2:
-            return raw * 0.3, None
-        else:
-            return 0, None
-
-    def buff_stats(self, level: int):
-        stats = {
-            "health": self.health,
-            "att_damage": self.attack["damage"],
-            "ult_damage": self.ult["damage"]
-        }
-
-        return super().buff_stats(stats, level)
-
-    def brawler_info(
-        self,
-        brawler_name: str,
-        trophies: int = None,
-        pb: int = None,
-        rank: int = None,
-        level: int = None,
-        pp: int = None,
-        next_level_pp: int = None,
-        sp1=False,
-        sp2=False
-    ):
-        """Return embed with Brawler info."""
-
-        embed = super().brawler_info(
-            brawler_name=brawler_name, trophies=trophies, pb=pb, rank=rank,
-            level=level, pp=pp, next_level_pp=next_level_pp, sp1=sp1, sp2=sp2
-        )
-
-        if not level:
-            level = 1
-
-        stats = self.buff_stats(level)
-
-        embed.add_field(
-            name="HEALTH",
-            value=f"{emojis['health']} {stats['health']}"
-        )
-        embed.add_field(name="SPEED", value=f"{emojis['speed']} {self.speed}")
-
-        attack_desc = f"```{self.attack['desc']}```"
-        attack_str = (
-            attack_desc
-            + f"\n{emojis['damage']} Damage per card: {stats['att_damage']}"
-        )
-        embed.add_field(name="ATTACK", value=attack_str, inline=False)
-
-        super_desc = f"```{self.ult['desc']}```"
-        super_str = (
-            super_desc
-            + f"\n{emojis['super']} Damage: {stats['ult_damage']}"
-        )
-        embed.add_field(name="SUPER", value=super_str, inline=False)
-
-        u1 = u2 = ""
-
-        if sp1:
-            u1 = " [Owned]"
-        if sp2:
-            u2 = " [Owned]"
-
-        sp_str = (
-            f"{sp_icons[brawler_name][0]} **{self.sp1['name']}**{u1}"
-            f"\n```k\n{self.sp1['desc']}```\n{sp_icons[brawler_name][1]}"
-            f" **{self.sp2['name']}**{u2}\n```k\n{self.sp2['desc']}```"
-        )
-
-        embed.add_field(name="STAR POWERS", value=sp_str, inline=False)
-
-        return embed
-
-
-class Spike(Brawler):
-    """A class to represent Spike."""
-
-    def _attack(self, level):
-        """Represent the attack ability of Spike."""
-
-        # getting all values
-        # att_range = self.attack["range"]
-        # att_reload = self.attack["reload"]
-        projectiles = self.attack["projectiles"]
-
-        stats = self.buff_stats(level)
-
-        damage = stats['att_damage']
-
-        raw = damage * projectiles * 0.8
-
-        chance = random.randint(0, 10)
-
-        if chance >= 9:
-            return raw
-        elif chance >= 6:
-            return raw * 0.7
-        elif chance >= 4:
-            return raw * 0.5
-        elif chance >= 2:
-            return raw * 0.3
-        else:
-            return 0
-
-    def _ult(self, level):
-        """Represent the Super ability of Spike."""
-
-        # getting all values
-        # ult_range = self.ult["range"]
-        projectiles = self.ult["projectiles"]
-
-        # special -- damage over time
-        duration = 0.3
-
-        stats = self.buff_stats(level)
-
-        damage = stats['ult_damage']
-        # damage over time
-        damage += damage * duration
-
-        raw = damage * projectiles * 0.8
-
-        chance = random.randint(0, 10)
-
-        if chance >= 9:
-            return raw, None
-        elif chance >= 6:
-            return raw * 0.7, None
-        elif chance >= 4:
-            return raw * 0.5, None
-        elif chance >= 2:
-            return raw * 0.3, None
-        else:
-            return 0, None
-
-    def buff_stats(self, level: int):
-        stats = {
-            "health": self.health,
-            "att_damage": self.attack["damage"],
-            "ult_damage": self.ult["damage"]
-        }
-
-        return super().buff_stats(stats, level)
-
-    def brawler_info(
-        self,
-        brawler_name: str,
-        trophies: int = None,
-        pb: int = None,
-        rank: int = None,
-        level: int = None,
-        pp: int = None,
-        next_level_pp: int = None,
-        sp1=False,
-        sp2=False
-    ):
-        """Return embed with Brawler info."""
-
-        embed = super().brawler_info(
-            brawler_name=brawler_name, trophies=trophies, pb=pb, rank=rank,
-            level=level, pp=pp, next_level_pp=next_level_pp, sp1=sp1, sp2=sp2
-        )
-
-        if not level:
-            level = 1
-
-        stats = self.buff_stats(level)
-
-        embed.add_field(
-            name="HEALTH",
-            value=f"{emojis['health']} {stats['health']}"
-        )
-        embed.add_field(name="SPEED", value=f"{emojis['speed']} {self.speed}")
-
-        attack_desc = f"```{self.attack['desc']}```"
-        attack_str = (
-            attack_desc
-            + f"\n{emojis['damage']} Damage per spike: {stats['att_damage']}"
-        )
-        embed.add_field(name="ATTACK", value=attack_str, inline=False)
-
-        super_desc = f"```{self.ult['desc']}```"
-        super_str = (
-            super_desc
-            + f"\n{emojis['super']} Damage per second: {stats['ult_damage']}"
-        )
-        embed.add_field(name="SUPER", value=super_str, inline=False)
-
-        u1 = u2 = ""
-
-        if sp1:
-            u1 = " [Owned]"
-        if sp2:
-            u2 = " [Owned]"
-
-        sp_str = (
-            f"{sp_icons[brawler_name][0]} **{self.sp1['name']}**{u1}"
-            f"\n```k\n{self.sp1['desc']}```\n{sp_icons[brawler_name][1]}"
-            f" **{self.sp2['name']}**{u2}\n```k\n{self.sp2['desc']}```"
-        )
-
-        embed.add_field(name="STAR POWERS", value=sp_str, inline=False)
-
-        return embed
-
-
+# Overrides `init`, `_attack`, `_ult` and `attack_info` methods to factor in poison damage.
 class Crow(Brawler):
-    """A class to represent Crow."""
+    """Class to represent Crow."""
+
+    def init(self):
+        self.stats = {
+            "health": self.health,
+            "att_damage": self.attack["damage"],
+            "poison_damage": self.attack["poison_damage"],
+            "ult_damage": self.ult["damage"]
+        }
 
     def _attack(self, level):
-        """Represent the attack ability of Crow."""
+        """Represents the attack ability of Crow."""
 
         # getting all values
         # att_range = self.attack["range"]
@@ -2982,21 +521,10 @@ class Crow(Brawler):
 
         raw = damage * projectiles * 0.8
 
-        chance = random.randint(0, 10)
-
-        if chance >= 9:
-            return raw
-        elif chance >= 6:
-            return raw * 0.7
-        elif chance >= 4:
-            return raw * 0.5
-        elif chance >= 2:
-            return raw * 0.3
-        else:
-            return 0
+        return self.chance_calculation(raw)
 
     def _ult(self, level):
-        """Represent the Super ability of Crow."""
+        """Represents the Super ability of Crow."""
 
         # getting all values
         # ult_range = self.ult["range"]
@@ -3011,90 +539,104 @@ class Crow(Brawler):
 
         raw = damage * projectiles * 0.8
 
-        chance = random.randint(0, 10)
+        return self.chance_calculation(raw), None
 
-        if chance >= 9:
-            return raw, None
-        elif chance >= 6:
-            return raw * 0.7, None
-        elif chance >= 4:
-            return raw * 0.5, None
-        elif chance >= 2:
-            return raw * 0.3, None
-        else:
-            return 0, None
-
-    def buff_stats(self, level: int):
-        stats = {
-            "health": self.health,
-            "att_damage": self.attack["damage"],
-            "poison_damage": self.attack["poison_damage"],
-            "ult_damage": self.ult["damage"]
-        }
-
-        return super().buff_stats(stats, level)
-
-    def brawler_info(
-        self,
-        brawler_name: str,
-        trophies: int = None,
-        pb: int = None,
-        rank: int = None,
-        level: int = None,
-        pp: int = None,
-        next_level_pp: int = None,
-        sp1=False,
-        sp2=False
-    ):
-        """Return embed with Brawler info."""
-
-        embed = super().brawler_info(
-            brawler_name=brawler_name, trophies=trophies, pb=pb, rank=rank,
-            level=level, pp=pp, next_level_pp=next_level_pp, sp1=sp1, sp2=sp2
-        )
-
-        if not level:
-            level = 1
-
-        stats = self.buff_stats(level)
-
-        embed.add_field(
-            name="HEALTH",
-            value=f"{emojis['health']} {stats['health']}"
-        )
-        embed.add_field(name="SPEED", value=f"{emojis['speed']} {self.speed}")
+    def attack_info(self, stats):
+        try:
+            attack_str = self.attack['extra']
+        except KeyError:
+            attack_str = "Damage"
 
         attack_desc = f"```{self.attack['desc']}```"
-        attack_str = (
-            attack_desc
-            + f"\n{emojis['damage']} Damage per dagger: {stats['att_damage']}"
-            + f"\n{emojis['damage']} Poison damage: {stats['poison_damage']}"
-        )
-        embed.add_field(name="ATTACK", value=attack_str, inline=False)
 
-        super_desc = f"```{self.ult['desc']}```"
-        super_str = (
-            super_desc
-            + f"\n{emojis['super']} Damage per dagger: {stats['ult_damage']}"
-        )
-        embed.add_field(name="SUPER", value=super_str, inline=False)
-
-        u1 = u2 = ""
-
-        if sp1:
-            u1 = " [Owned]"
-        if sp2:
-            u2 = " [Owned]"
-
-        sp_str = (
-            f"{sp_icons[brawler_name][0]} **{self.sp1['name']}**{u1}"
-            f"\n```k\n{self.sp1['desc']}```\n{sp_icons[brawler_name][1]}"
-            f" **{self.sp2['name']}**{u2}\n```k\n{self.sp2['desc']}```"
+        info = (
+            "{desc}\n{att_emote} {extra}: {damage} \n{att_emote} Poison damage: {poison}"
+        ).format(
+            desc=attack_desc,
+            att_emote=emojis['damage'],
+            extra=attack_str,
+            damage=stats['att_damage'],
+            poison=stats['poison_damage']
         )
 
-        embed.add_field(name="STAR POWERS", value=sp_str, inline=False)
+        return info
 
-        return embed
+
+# GENERAL BRAWLER CLASSES
+# These exist just for the sake of having a class for each Brawler.
+# They simply inherit from appropriate base classes
+# (`Brawler`, `Healer`, `Spawner` or `HealSpawner`).
+
+class Shelly(Brawler):
+    """Class to represent Shelly."""
+
+
+class Nita(Spawner):
+    """Class to represent Nita."""
+
+
+class Colt(Brawler):
+    """Class to represent Colt."""
+
+
+class Bull(Brawler):
+    """Class to represent Bull."""
+
+
+class Jessie(Spawner):
+    """Class to represent Jessie."""
+
+
+class Brock(Brawler):
+    """Class to represent Brock."""
+
+
+class Dynamike(Brawler):
+    """Class to represent Dynamike."""
+
+
+class ElPrimo(Brawler):
+    """Class to represent El Primo."""
+
+
+class Poco(Healer):
+    """Class to represent Poco."""
+
+
+class Rico(Brawler):
+    """Class to represent Rico."""
+
+
+class Darryl(Brawler):
+    """Class to represent Darryl."""
+
+
+class Penny(Spawner):
+    """Class to represent Penny."""
+
+
+class Bo(Brawler):
+    """Class to represent Bo."""
+
+
+class Pam(HealSpawner):
+    """Class to represent Pam."""
+
+
+class Mortis(Brawler):
+    """Class to represent Mortis."""
+
+
+class Frank(Brawler):
+    """Class to represent Frank."""
+
+
+class Tara(Brawler):
+    """Class to represent Tara."""
+
+
+class Spike(Brawler):
+    """Class to represent Spike."""
 
 
 brawlers_map = {

--- a/brawlcord/data/brawlers.json
+++ b/brawlcord/data/brawlers.json
@@ -53,7 +53,7 @@
         "ult": {
             "name": "Overbearing",
             "desc": "Nita summons the spirit of Big Baby Bear to hunt down her enemies.",
-            "bear": {
+            "spawn": {
                 "health": 4000,
                 "damage": 400,
                 "range": 1.33,
@@ -164,7 +164,7 @@
         "ult": {
             "name": "Scrappy!",
             "desc": "Jessie deploys a gun turret that automatically shoots at enemies. It's made of 100% recycled materials!",
-            "scrappy": {
+            "spawn": {
                 "health": 2800,
                 "damage": 260,
                 "range": 4.67,
@@ -385,10 +385,12 @@
         "unlockTrp": -1,
         "ult": {
             "name": "Encore",
+            "damage": null,
             "heal": 2100,
             "desc": "Poco heals himself and all friends he can reach with his uplifting melody. Does not affect enemies.",
             "range": 10.33,
-            "projectiles": 1
+            "projectiles": 1,
+            "extra": "Heal"
         },
         "sp1": {
             "name": "Da Capo",
@@ -488,7 +490,7 @@
         "ult": {
             "name": "Old Lobber",
             "desc": "Penny sets up her cannon! It can shoot at enemies at a long range, even if they are behind cover.",
-            "cannon": {
+            "spawn": {
                 "health": 2800,
                 "damage": 1200,
                 "range": 14.33,
@@ -602,8 +604,9 @@
             "name": "Mama's Kiss'",
             "desc": "Pam's healing turret will fix up her and teammates who stay in its area of effect.",
             "extra": "Heal per second",
-            "turret": {
+            "spawn": {
                 "health": 2800,
+                "damage": null,
                 "heal": 320,
                 "range": 5,
                 "name": "Healing Turret"

--- a/brawlcord/shop.py
+++ b/brawlcord/shop.py
@@ -25,7 +25,7 @@ class Shop:
         self.items = {
             "powerpoints": (2, 100),
             "starpowers": (2000, 10),
-            "brawlbox": (0, 10),
+            "brawlbox": (0, 20),
             "tickets": (0, 10)
         }
 

--- a/brawlcord/utils.py
+++ b/brawlcord/utils.py
@@ -467,8 +467,10 @@ class Box:
         free_skins = [
             skin for skin in self.BRAWLERS[brawler]["skins"] if skin[0] == 0
         ]
+
         async with conf.brawlers() as brawlers:
-            default_stats["skins"].append(free_skins)
+            if free_skins:
+                default_stats["skins"].extend(free_skins)
             brawlers[brawler] = default_stats
         embed.add_field(
             name=f"New {rarity} Brawler :tada:",


### PR DESCRIPTION
There was an issue with `Box.unlock_brawler` command that appended empty lists to the new Brawlers' skins data. It has been fixed in this update.

The chances of a free brawl box appearing in the daily shop have also been doubled.

Additionally, brawler classes were completely refactored to allow for easy and efficient customisation.